### PR TITLE
fix: set locale date to id

### DIFF
--- a/face-attendance-frontend/app/(dashboard)/attendances/page.tsx
+++ b/face-attendance-frontend/app/(dashboard)/attendances/page.tsx
@@ -24,7 +24,7 @@ import { getAttendances } from '@/actions/attendance.actions'
  */
 function formatCheckinTime(dateString: string): string {
   if (!dateString) return 'N/A'
-  return new Date(dateString).toLocaleString(undefined, {
+  return new Date(dateString).toLocaleString('id-ID', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/face-attendance-frontend/app/(dashboard)/students/page.tsx
+++ b/face-attendance-frontend/app/(dashboard)/students/page.tsx
@@ -29,7 +29,7 @@ import { DeleteStudentButton } from './components/DeleteStudentButton'
  */
 function formatCreatedAt(dateString: string): string {
   if (!dateString) return 'N/A'
-  return new Date(dateString).toLocaleString(undefined, {
+  return new Date(dateString).toLocaleString('id-ID', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',


### PR DESCRIPTION
This pull request updates date formatting across multiple pages in the `face-attendance-frontend` project to ensure consistency and localization. The changes involve specifying the `id-ID` locale for `toLocaleString` calls.

Localization updates:

* [`face-attendance-frontend/app/(dashboard)/attendances/page.tsx`](diffhunk://#diff-5b358abe333c1b81743c7999b5b155d98c9497a5e3bc00a826b98e85058ebd83L27-R27): Changed the locale in the `formatCheckinTime` function from `undefined` to `'id-ID'` for consistent Indonesian date formatting.
* [`face-attendance-frontend/app/(dashboard)/students/page.tsx`](diffhunk://#diff-5a237735d4e3a938c948b4c73906eef0877c7a96ed7e04fa980f3a370c171cefL32-R32): Updated the locale in the `formatCreatedAt` function from `undefined` to `'id-ID'` to align with Indonesian date formatting standards.