### PR TITLE
fix: set locale date to id

### DIFF
--- a/face-attendance-frontend/app/(dashboard)/attendances/page.tsx
+++ b/face-attendance-frontend/app/(dashboard)/attendances/page.tsx
@@ -24,14 +24,15 @@ import { getAttendances } from '@/actions/attendance.actions'
  */
 function formatCheckinTime(dateString: string): string {
   if (!dateString) return 'N/A'
-  return new Date(dateString).toLocaleString('id-ID', {
+  return new Intl.DateTimeFormat('id-ID', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
     hour12: false,
-  })
+    timeZone: 'Asia/Jakarta'
+  }).format(new Date(dateString))
 }
 
 /**

--- a/face-attendance-frontend/app/(dashboard)/students/page.tsx
+++ b/face-attendance-frontend/app/(dashboard)/students/page.tsx
@@ -29,14 +29,15 @@ import { DeleteStudentButton } from './components/DeleteStudentButton'
  */
 function formatCreatedAt(dateString: string): string {
   if (!dateString) return 'N/A'
-  return new Date(dateString).toLocaleString('id-ID', {
+  return new Intl.DateTimeFormat('id-ID', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
     hour12: false,
-  })
+    timeZone: 'Asia/Jakarta'
+  }).format(new Date(dateString))
 }
 
 /**


### PR DESCRIPTION
This pull request updates date formatting logic in two files to use `Intl.DateTimeFormat` instead of `toLocaleString`. The changes ensure consistent formatting and explicitly set the time zone to `Asia/Jakarta`.

Date formatting improvements:

* [`face-attendance-frontend/app/(dashboard)/attendances/page.tsx`](diffhunk://#diff-5b358abe333c1b81743c7999b5b155d98c9497a5e3bc00a826b98e85058ebd83L27-R35): Updated the `formatCheckinTime` function to use `Intl.DateTimeFormat` for date formatting, adding explicit `timeZone: 'Asia/Jakarta'` for consistency.
* [`face-attendance-frontend/app/(dashboard)/students/page.tsx`](diffhunk://#diff-5a237735d4e3a938c948b4c73906eef0877c7a96ed7e04fa980f3a370c171cefL32-R40): Updated the `formatCreatedAt` function to use `Intl.DateTimeFormat` with `timeZone: 'Asia/Jakarta'`, ensuring consistent date formatting across the application.