### PR TITLE
docs: fix url github in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Make sure you have the following tools installed on your system:
 
 1.  **Clone the Repository**
     ```bash
-    git clone [https://github.com/your-username/face-attendance-management-system.git](https://github.com/your-username/face-attendance-management-system.git)
-    cd face-attendance-management-system
+    git clone [https://github.com/ferriprasetya/face-attendance-nextjs-supabase.git](https://github.com/ferriprasetya/face-attendance-nextjs-supabase.git)
+    cd face-attendance-nextjs-supabase
     ```
 
 2.  **Set Up the Backend (Supabase)**


### PR DESCRIPTION
This pull request updates the repository information in the `README.md` file to reflect the correct project name and URL.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R67): Changed the repository URL and folder name from `face-attendance-management-system` to `face-attendance-nextjs-supabase` to align with the updated project structure.